### PR TITLE
feat: apply feedbacks from INRAE

### DIFF
--- a/backend/src/main/java/fr/inrae/urgi/faidare/web/observation/ObservationExportService.java
+++ b/backend/src/main/java/fr/inrae/urgi/faidare/web/observation/ObservationExportService.java
@@ -19,6 +19,7 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.opencsv.CSVWriter;
 import fr.inrae.urgi.faidare.domain.brapi.v2.observationUnits.ObservationUnitV2VO;
@@ -116,7 +117,7 @@ public class ObservationExportService {
         List<JsonObservationVariable> observationVariables =
             getDistinctVariables(rows)
                 .stream()
-                .map(v -> new JsonObservationVariable(decode(v.id()), v.name()))
+                .map(v -> new JsonObservationVariable(v.id(), v.name()))
                 .toList();
 
         List<List<String>> data =
@@ -150,9 +151,10 @@ public class ObservationExportService {
             return List.of();
         }
 
-        // each year/season has its row.
-        // but if there are several observation for the same variable and the same year, then it goes to a different row
-        Map<String, List<Row>> rowsBySeason = new TreeMap<>();
+        // each year/season + GDD has its row.
+        // but if there are several observations for the same variable and the
+        // same year + GDD, then the duplicates go to a different row
+        Map<SeasonAndGdd, List<Row>> rowsBySeasonAndGdd = new TreeMap<>();
         List<ObservationVO> observationsSortedByTimestamp =
             exportedObservationUnit
                 .observations()
@@ -161,21 +163,23 @@ public class ObservationExportService {
                 .toList();
         for (var observation : observationsSortedByTimestamp) {
             String season = observation.getSeason().getSeasonName();
+            Float gdd = observation.getGdd();
+            SeasonAndGdd seasonAndGdd = new SeasonAndGdd(season, gdd);
             String observationVariableDbId = observation.getObservationVariableDbId();
 
-            List<Row> rowsOfSeason = rowsBySeason.computeIfAbsent(season, ignored -> new ArrayList<>());
-            Row row = rowsOfSeason
+            List<Row> rowsOfSeasonAndGdd = rowsBySeasonAndGdd.computeIfAbsent(seasonAndGdd, ignored -> new ArrayList<>());
+            Row row = rowsOfSeasonAndGdd
                 .stream()
                 .filter(r -> !r.observationsByVariableDbId.containsKey(observationVariableDbId))
                 .findFirst()
                 .orElseGet(() -> {
                     Row newRow = new Row(exportedObservationUnit.observationUnit(), new HashMap<>());
-                    rowsOfSeason.add(newRow);
+                    rowsOfSeasonAndGdd.add(newRow);
                     return newRow;
                 });
             row.observationsByVariableDbId().put(observationVariableDbId, observation);
         }
-        return rowsBySeason.values().stream().flatMap(List::stream).toList();
+        return rowsBySeasonAndGdd.values().stream().flatMap(List::stream).toList();
     }
 
     private List<Row> createJsonRows(List<ExportedObservationUnit> observationUnits) {
@@ -203,14 +207,14 @@ public class ObservationExportService {
 
         columns.add(
             new Column(
-                new Header("Observation Unit ID", "observationUnitDbId"),
+                new Header("obsUnitId", "observationUnitDbId"),
                 row -> decode(row.observationUnit().getObservationUnitDbId())
             )
         );
 
         columns.add(
             new Column(
-                new Header("Observation Unit Name", "observationUnitName"),
+                new Header("observationUnitName", "observationUnitName"),
                 row -> row.observationUnit().getObservationUnitName()
             )
         );
@@ -218,21 +222,21 @@ public class ObservationExportService {
 
         columns.add(
             new Column(
-                new Header("Observation Level", "observationLevel"),
+                new Header("obsUnitType", "observationLevel"),
                 row -> row.observationUnit().getObservationUnitPosition().getObservationLevel().getLevelOrder()
             )
         );
 
         columns.add(
             new Column(
-                new Header("Germplasm ID", "germplasmDbId"),
+                new Header("germplasmId", "germplasmDbId"),
                 row -> decode(row.observationUnit().getGermplasmDbId())
             )
         );
 
         columns.add(
             new Column(
-                new Header("Germplasm Name", "germplasmName"),
+                new Header("germplasmName", "germplasmName"),
                 row -> row.observationUnit().getGermplasmName()
             )
         );
@@ -240,55 +244,78 @@ public class ObservationExportService {
 
         columns.add(
             new Column(
-                new Header("Germplasm Genus", "germplasmGenus"),
+                new Header("genus", "germplasmGenus"),
                 row -> row.observationUnit().getGermplasmGenus()
             )
         );
 
         columns.add(
             new Column(
-                new Header("Trial Name", "trialName"),
+                new Header("trialName", "trialName"),
                 row -> row.observationUnit().getTrialName()
             )
         );
 
         columns.add(
             new Column(
-                new Header("Study ID", "studyDbId"),
+                new Header("studyId", "studyDbId"),
                 row -> decode(row.observationUnit().getStudyDbId())
             )
         );
 
         columns.add(
             new Column(
-                new Header("Study Name", "studyName"),
+                new Header("studyName", "studyName"),
                 row -> row.observationUnit().getStudyName()
             )
         );
 
         columns.add(
             new Column(
-                new Header("Study Location", "studyLocation"),
+                new Header("siteName", "studyLocation"),
                 row -> row.observationUnit().getStudyLocation()
             )
         );
 
+        List<String> distinctTreatmentFactors =
+            rows.stream()
+                .flatMap(row ->
+                             row.observationUnit().getTreatments() == null
+                                 ? Stream.empty()
+                                 : row.observationUnit().getTreatments().stream()
+                )
+                .map(TreatmentVO::getFactor)
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted()
+                .toList();
+
+        for (String treatmentFactor: distinctTreatmentFactors) {
+            columns.add(
+                new Column(
+                    new Header(treatmentFactor, treatmentFactor),
+                    row -> row.observationUnit()
+                              .getTreatments()
+                              .stream()
+                              .filter(treatment -> treatmentFactor.equals(treatment.getFactor()))
+                              .map(TreatmentVO::getModality)
+                              .findAny()
+                              .orElse(null)
+                )
+            );
+        }
+
         columns.add(
             new Column(
-                new Header("Treatments", "treatments"),
-                row -> row.observationUnit()
-                          .getTreatments()
-                          .stream()
-                          .map(TreatmentVO::getModality)
-                          .filter(Objects::nonNull)
-                          .collect(Collectors.joining(", "))
+                new Header("season", "year"),
+                Row::getSeason
             )
         );
 
         columns.add(
             new Column(
-                new Header("Season", "year"),
-                Row::getSeason
+                new Header("gdd", "gdd"),
+                Row::getGdd
             )
         );
 
@@ -296,7 +323,7 @@ public class ObservationExportService {
             columns.add(
                 new Column(
                     new Header(null, "observationTimeStamp"),
-                    row -> row.observationsByVariableDbId.values().iterator().next().getObservationTimeStamp()
+                    Row::getFirstObservationTimeStamp
                 )
             );
         }
@@ -306,7 +333,7 @@ public class ObservationExportService {
         for (Variable variable : distinctVariables) {
             columns.add(
                 new Column(
-                    new Header(String.format("%s(%s)", variable.name(), decode(variable.id())), null),
+                    new Header(String.format("%s(%s)", variable.name(), variable.id()), null),
                     row -> {
                         ObservationVO observation = row.observationsByVariableDbId.get(variable.id());
                         if (observation == null) {
@@ -320,7 +347,7 @@ public class ObservationExportService {
             if (exportFormat != ExportFormat.JSON) {
                 columns.add(
                     new Column(
-                        new Header(String.format("%s(%s)_date", variable.name(), decode(variable.id())), null),
+                        new Header(String.format("%s(%s)_date", variable.name(), variable.id()), null),
                         row -> {
                             ObservationVO observation = row.observationsByVariableDbId.get(variable.id());
                             if (observation == null) {
@@ -391,7 +418,7 @@ public class ObservationExportService {
     }
 
     /**
-     * A row, having at least one observation, and where all observations have the same year/season.
+     * A row, having at least one observation, and where all observations have the same year/season and GDD.
      * There is at most one observation for a given observationVariableDbId.
      * JSON rows have only one observation in the map.
      */
@@ -401,6 +428,15 @@ public class ObservationExportService {
     ) {
         String getSeason() {
             return observationsByVariableDbId.values().iterator().next().getSeason().getSeasonName();
+        }
+
+        String getGdd() {
+            Float gdd = observationsByVariableDbId.values().iterator().next().getGdd();
+            return gdd == null ? null : gdd.toString();
+        }
+
+        String getFirstObservationTimeStamp() {
+            return observationsByVariableDbId.values().iterator().next().getObservationTimeStamp();
         }
     }
 
@@ -463,6 +499,17 @@ public class ObservationExportService {
     }
 
     private record Variable(String id, String name) {}
+
+    private record SeasonAndGdd(String season, Float gdd) implements Comparable<SeasonAndGdd> {
+        private static final Comparator<SeasonAndGdd> COMPARATOR =
+            Comparator.comparing(SeasonAndGdd::season)
+                      .thenComparing(SeasonAndGdd::gdd, Comparator.nullsFirst(Comparator.naturalOrder()));
+
+        @Override
+        public int compareTo(SeasonAndGdd o) {
+            return COMPARATOR.compare(this, o);
+        }
+    }
 
     /**
      * A column header. The label is used for CSV and Excel. The jsonLabel is used

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -149,9 +149,6 @@ spring:
     activate:
       on-profile:
         e2e
-  elasticsearch:
-    uris:
-      - http://elasticsearch:9200
 server:
   port: 8381
 

--- a/backend/src/main/resources/templates/trial.html
+++ b/backend/src/main/resources/templates/trial.html
@@ -80,7 +80,7 @@
                 >
                   <button
                     class="dropdown-item"
-                    th:text="${levelCode}"
+                    th:text="${'Level: ' + levelCode}"
                     data-bs-toggle="modal"
                     data-bs-target="#exportModal"
                     th:attr="data-level-code=${levelCode}"

--- a/backend/src/test/java/fr/inrae/urgi/faidare/web/observation/ObservationExportServiceTest.java
+++ b/backend/src/test/java/fr/inrae/urgi/faidare/web/observation/ObservationExportServiceTest.java
@@ -40,19 +40,20 @@ class ObservationExportServiceTest {
         ExportedObservationUnit unit1 = new ExportedObservationUnit(
             createObservationUnit(1),
             List.of(
-                createObservation("2015", 1), // row 1
-                createObservation("2015", 2), // row 1 (same year, different variable)
-                createObservation("2015", 3), // row 1 (same year, different variable)
-                createObservation("2015", 1), // row 2 (same year, same variable)
-                createObservation("2016", 1), // row 3 (different year)
-                createObservation("2016", 2) // row 3  (different year, different variable)
+                createObservation("2015", 1.0F, 1), // row 1
+                createObservation("2015", 1.0F, 2), // row 1 (same year, same gdd, different variable)
+                createObservation("2015", 1.0F, 3), // row 1 (same year, same gdd different variable)
+                createObservation("2015", 1.0F, 1), // row 2 (same year, same gdd, same variable)
+                createObservation("2015", 2.0F, 1), // row 3 (same year, different gdd, same variable)
+                createObservation("2016", 2.0F, 1), // row 4 (different year, different gdd)
+                createObservation("2016", 2.0F, 2) // row 4  (different year, different gdd, different variable)
             )
         );
         ExportedObservationUnit unit2 = new ExportedObservationUnit(
             createObservationUnit(2),
             List.of(
-                createObservation("2015", 1), // row 4
-                createObservation("2015", 2)  // row 4 (same year, different variable)
+                createObservation("2015", 1.0F, 1), // row 5
+                createObservation("2015", 1.0F, 2)  // row 5 (same year, same gdd)
             )
         );
 
@@ -69,21 +70,23 @@ class ObservationExportServiceTest {
         ).build();
         List<String[]> lines = csvReader.readAll();
 
-        assertThat(lines).hasSize(5);
+        assertThat(lines).hasSize(6);
         String[] header = lines.getFirst();
         assertThat(header).containsExactly(
-            "Observation Unit ID",
-            "Observation Unit Name",
-            "Observation Level",
-            "Germplasm ID",
-            "Germplasm Name",
-            "Germplasm Genus",
-            "Trial Name",
-            "Study ID",
-            "Study Name",
-            "Study Location",
-            "Treatments",
-            "Season",
+            "obsUnitId",
+            "observationUnitName",
+            "obsUnitType",
+            "germplasmId",
+            "germplasmName",
+            "genus",
+            "trialName",
+            "studyId",
+            "studyName",
+            "siteName",
+            "factor1",
+            "factor2",
+            "season",
+            "gdd",
             "Variable 1(variable1)",
             "Variable 1(variable1)_date",
             "Variable 2(variable2)",
@@ -102,8 +105,10 @@ class ObservationExportServiceTest {
             "study1",
             "Study 1",
             "Location 1",
-            "Modality",
+            "modality1",
+            "modality2",
             "2015",
+            "1.0",
             "v1",
             "2015-01-01T01:00:00Z",
             "v2",
@@ -122,8 +127,10 @@ class ObservationExportServiceTest {
             "study1",
             "Study 1",
             "Location 1",
-            "Modality",
+            "modality1",
+            "modality2",
             "2015",
+            "1.0",
             "v1",
             "2015-01-01T01:00:00Z",
             "",
@@ -142,8 +149,32 @@ class ObservationExportServiceTest {
             "study1",
             "Study 1",
             "Location 1",
-            "Modality",
+            "modality1",
+            "modality2",
+            "2015",
+            "2.0",
+            "v1",
+            "2015-01-01T01:00:00Z",
+            "",
+            "",
+            "",
+            ""
+        );
+        assertThat(lines.get(4)).containsExactly(
+            "unit1",
+            "Unit1",
+            "levelCode",
+            "germplasm1",
+            "Germplasm 1",
+            "Germplasm Genus 1",
+            "Trial 1",
+            "study1",
+            "Study 1",
+            "Location 1",
+            "modality1",
+            "modality2",
             "2016",
+            "2.0",
             "v1",
             "2016-01-01T01:00:00Z",
             "v2",
@@ -151,7 +182,7 @@ class ObservationExportServiceTest {
             "",
             ""
         );
-        assertThat(lines.get(4)).containsExactly(
+        assertThat(lines.get(5)).containsExactly(
             "unit2",
             "Unit2",
             "levelCode",
@@ -162,8 +193,10 @@ class ObservationExportServiceTest {
             "study2",
             "Study 2",
             "Location 2",
-            "Modality",
+            "modality1",
+            "modality2",
             "2015",
+            "1.0",
             "v1",
             "2015-01-01T01:00:00Z",
             "v2",
@@ -182,19 +215,20 @@ class ObservationExportServiceTest {
         ExportedObservationUnit unit1 = new ExportedObservationUnit(
             createObservationUnit(1),
             List.of(
-                createObservation("2015", 1),
-                createObservation("2015", 2),
-                createObservation("2015", 3),
-                createObservation("2015", 1),
-                createObservation("2016", 1),
-                createObservation("2016", 2)
+                createObservation("2015", 1.0F, 1),
+                createObservation("2015", 1.0F, 2),
+                createObservation("2015", 1.0F, 3),
+                createObservation("2015", 1.0F, 1),
+                createObservation("2015", 2.0F, 1),
+                createObservation("2016", 2.0F, 1),
+                createObservation("2016", 2.0F, 2)
             )
         );
         ExportedObservationUnit unit2 = new ExportedObservationUnit(
             createObservationUnit(2),
             List.of(
-                createObservation("2015", 1),
-                createObservation("2015", 2)
+                createObservation("2015", 1.0F, 1),
+                createObservation("2015", 1.0F, 2)
             )
         );
 
@@ -218,8 +252,10 @@ class ObservationExportServiceTest {
                 "studyDbId",
                 "studyName",
                 "studyLocation",
-                "treatments",
+                "factor1",
+                "factor2",
                 "year",
+                "gdd",
                 "observationTimeStamp"
               ],
               "observationVariables": [
@@ -248,8 +284,10 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "1.0",
                   "2015-01-01T01:00:00Z",
                   "v1",
                   null,
@@ -266,8 +304,10 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "1.0",
                   "2015-01-01T01:00:00Z",
                   "v1",
                   null,
@@ -284,8 +324,30 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "2.0",
+                  "2015-01-01T01:00:00Z",
+                  "v1",
+                  null,
+                  null
+                ],
+                [
+                  "unit1",
+                  "Unit1",
+                  "levelCode",
+                  "germplasm1",
+                  "Germplasm 1",
+                  "Germplasm Genus 1",
+                  "Trial 1",
+                  "study1",
+                  "Study 1",
+                  "Location 1",
+                  "modality1",
+                  "modality2",
+                  "2015",
+                  "1.0",
                   "2015-01-01T02:00:00Z",
                   null,
                   "v2",
@@ -302,8 +364,10 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "1.0",
                   "2015-01-01T03:00:00Z",
                   null,
                   null,
@@ -320,8 +384,10 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2016",
+                  "2.0",
                   "2016-01-01T01:00:00Z",
                   "v1",
                   null,
@@ -338,8 +404,10 @@ class ObservationExportServiceTest {
                   "study1",
                   "Study 1",
                   "Location 1",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2016",
+                  "2.0",
                   "2016-01-01T02:00:00Z",
                   null,
                   "v2",
@@ -356,8 +424,10 @@ class ObservationExportServiceTest {
                   "study2",
                   "Study 2",
                   "Location 2",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "1.0",
                   "2015-01-01T01:00:00Z",
                   "v1",
                   null,
@@ -374,8 +444,10 @@ class ObservationExportServiceTest {
                   "study2",
                   "Study 2",
                   "Location 2",
-                  "Modality",
+                  "modality1",
+                  "modality2",
                   "2015",
+                  "1.0",
                   "2015-01-01T02:00:00Z",
                   null,
                   "v2",
@@ -400,13 +472,13 @@ class ObservationExportServiceTest {
         vo.setStudyDbId(encode("study" + index));
         vo.setStudyName("Study " + index);
         vo.setStudyLocation("Location " + index);
-        vo.setTreatments(List.of(createTreatment()));
+        vo.setTreatments(List.of(createTreatment(1), createTreatment(2)));
         return vo;
     }
 
-    private ObservationVO createObservation(String year, int index) {
+    private ObservationVO createObservation(String year, Float gdd, int index) {
         ObservationVO vo = new ObservationVO();
-        vo.setObservationVariableDbId(encode("variable" + index));
+        vo.setObservationVariableDbId("variable" + index);
         vo.setObservationVariableName("Variable " + index);
         vo.setValue("v" + index);
         vo.setObservationTimeStamp("2025-12-03T13:00:00Z");
@@ -415,13 +487,14 @@ class ObservationExportServiceTest {
         season.setSeasonName(year);
         vo.setSeason(season);
         vo.setObservationTimeStamp(Instant.parse(year + "-01-01T0" + index + ":00:00Z").toString());
+        vo.setGdd(gdd);
         return vo;
     }
 
-    private TreatmentVO createTreatment() {
+    private TreatmentVO createTreatment(int index) {
         TreatmentVO vo = new TreatmentVO();
-        vo.setFactor("Factor");
-        vo.setModality("Modality");
+        vo.setFactor("factor" + index);
+        vo.setModality("modality" + index);
         return vo;
     }
 

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -51,9 +51,9 @@ tasks {
     }
 
     val e2e by registering(PnpmTask::class) {
-        // On CI, we need to start the app with a different postgres host
+        // On CI, we need to start the app with a different postgres and elastic host
         // so we have a dedicated task in the package.json
-        if (project.findProperty("CI") != null) {
+        if (System.getenv("CI") != null) {
             args.set(listOf("run", "e2e:standalone:ci"))
             environment.put("CI", "true")
         } else {

--- a/web/e2e/tests/trial.spec.ts
+++ b/web/e2e/tests/trial.spec.ts
@@ -8,7 +8,7 @@ test.describe('Trial', () => {
     await expect(page.getByRole('heading', { level: 1 })).toHaveText('Trial Network: Drops Phenotyping Network');
 
     await page.getByRole('button', { name: 'Export observations' }).click();
-    await page.getByRole('button', { name: 'VIRTUAL_TRIAL' }).click();
+    await page.getByRole('button', { name: 'Level: VIRTUAL_TRIAL' }).click();
 
     await expect(page.getByRole('heading', { level: 1, name: 'Export observations for trial Drops Phenotyping Network' })).toBeVisible();
 


### PR DESCRIPTION
- Add "Level: " before the level value in the opbservation export dropdown
- Change the column headers for CSV and Excel
- Avoid base64-decoding the observation variable DB ID
- Replace the "Treatments" column containg coma-separated treatment modalities by one column per treatment factor
- Add gdd column and group variables by season + gdd rather than only season