### PR TITLE
test: disable Anubis-protected ontology tests

### DIFF
--- a/backend/src/test/java/fr/inrae/urgi/faidare/api/brapi/v1/ObservationVariableV1ControllerTest.java
+++ b/backend/src/test/java/fr/inrae/urgi/faidare/api/brapi/v1/ObservationVariableV1ControllerTest.java
@@ -9,6 +9,7 @@ package fr.inrae.urgi.faidare.api.brapi.v1;
 import com.jayway.jsonpath.JsonPath;
 import fr.inrae.urgi.faidare.Application;
 import fr.inrae.urgi.faidare.domain.variable.ObservationVariableV1VO;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+// These endpoints load live ontology data from URGI URLs that are now protected by Anubis.
+@Disabled("URGI ontology endpoints are now protected by Anubis")
 class ObservationVariableV1ControllerTest {
 
     @Value("${server.servlet.context-path}")

--- a/web/e2e/tests/trial.spec.ts
+++ b/web/e2e/tests/trial.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Trial', () => {
-  test('should display the trial page and export', async ({ page, context }) => {
+  // This page loads live ontology data from URGI URLs that are now protected by Anubis.
+  test.skip('should display the trial page and export', async ({ page, context }) => {
     test.setTimeout(45_000);
     await page.goto('/faidare-dev/trials/dXJuOklOUkFFLVVSR0kvdHJpYWwvNDI=');
 
@@ -59,7 +60,9 @@ test.describe('Trial', () => {
     const exportPagePromise = context.waitForEvent('page');
 
     await page.getByRole('button', { name: 'Export', exact: true }).click();
-    await expect(page.getByRole('heading', { level: 1, name: 'Export observations for trial Drops Phenotyping Network' })).not.toBeVisible();
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Export observations for trial Drops Phenotyping Network' })
+    ).not.toBeVisible();
 
     const exportPage = await exportPagePromise;
 


### PR DESCRIPTION
Repro command:

curl -sS -D - \
  -H 'Accept: application/json' \
  -H 'User-Agent: Java/21' \
  'https://urgi.versailles.inrae.fr/files/ephesis/trait-ontology/data_16.3/ontology-repository.json'
